### PR TITLE
Fix bugs, security, and performance issues from adversarial review

### DIFF
--- a/go/cmd/multicast-relay/main.go
+++ b/go/cmd/multicast-relay/main.go
@@ -154,6 +154,16 @@ func run() int {
 	log.Monitor("Process started (pid %d, version %s)", os.Getpid(), version)
 	log.Monitor("Parameters: %s", formatArgs())
 
+	// Warn loudly when remote relay is used without encryption: without --aes
+	// there is no cryptographic authentication of remote peers, and any host that
+	// can reach the port from an allowed source IP can inject packets onto local
+	// networks.
+	if (len(listenAddrs) > 0 || len(remoteAddrs) > 0) && aesKeyVal == "" {
+		warn := "Remote relay is running WITHOUT encryption (--aes). Remote peers are not cryptographically authenticated; use --aes with a strong shared key on untrusted networks."
+		log.Warning("%s", warn)
+		log.Monitor("%s", warn)
+	}
+
 	// Build relay set
 	type relayEntry struct {
 		addrPort string
@@ -327,6 +337,13 @@ func dropPrivileges(username string) error {
 	uid, err := strconv.Atoi(u.Uid)
 	if err != nil {
 		return fmt.Errorf("invalid UID %q for user %q: %w", u.Uid, username, err)
+	}
+	// Drop inherited supplementary groups before changing gid/uid. Without this,
+	// the process keeps root's supplementary group memberships (potentially
+	// including gid 0) after the drop, leaving privileges the "unprivileged" user
+	// should not hold.
+	if err := syscall.Setgroups([]int{gid}); err != nil {
+		return fmt.Errorf("setgroups(%d): %w", gid, err)
 	}
 	if err := syscall.Setgid(gid); err != nil {
 		return fmt.Errorf("setgid(%d): %w", gid, err)

--- a/go/internal/cipher/cipher.go
+++ b/go/internal/cipher/cipher.go
@@ -5,12 +5,28 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+)
+
+// Key derivation parameters. PBKDF2-HMAC-SHA256 with a high iteration count
+// gives the passphrase a work factor, so a low-entropy shared key is no longer
+// trivially brute-forceable from a captured frame or handshake. The salts are
+// fixed (both relay ends derive the same key from the same passphrase) but
+// distinct, providing domain separation between the AES and HMAC keys.
+const (
+	kdfIterations = 210_000
+	kdfKeyLen     = 32
+)
+
+var (
+	aesKDFSalt  = []byte("multicast-relay-kdf-aes-v1")
+	hmacKDFSalt = []byte("multicast-relay-kdf-hmac-v1")
 )
 
 // Cipher handles AES-256-GCM authenticated encryption and HMAC-based peer authentication.
@@ -23,22 +39,24 @@ type Cipher struct {
 }
 
 // New creates a new Cipher. If key is empty, encryption is disabled (passthrough).
-// When key is non-empty, two separate keys are derived via SHA-256 with domain separation:
-//   - AES key:  SHA-256(passphrase)
-//   - HMAC key: SHA-256("multicast-relay-auth-v1:" + passphrase)
+// When key is non-empty, two separate 256-bit keys are derived from the passphrase
+// via PBKDF2-HMAC-SHA256 with distinct salts for domain separation:
+//   - AES key:  PBKDF2(passphrase, aesKDFSalt)
+//   - HMAC key: PBKDF2(passphrase, hmacKDFSalt)
 func New(key string) (*Cipher, error) {
 	c := &Cipher{}
 	if key == "" {
 		return c, nil
 	}
 
-	keyBytes := []byte(key)
-
-	// Derive AES-256 key and zero the intermediate hash immediately after loading into the block cipher.
-	aesHash := sha256.Sum256(keyBytes)
-	block, err := aes.NewCipher(aesHash[:])
-	for i := range aesHash {
-		aesHash[i] = 0
+	// Derive the AES-256 key and zero it immediately after loading into the block cipher.
+	aesKey, err := pbkdf2.Key(sha256.New, key, aesKDFSalt, kdfIterations, kdfKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("cipher: failed to derive AES key: %w", err)
+	}
+	block, err := aes.NewCipher(aesKey)
+	for i := range aesKey {
+		aesKey[i] = 0
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cipher: failed to create AES block: %w", err)
@@ -49,23 +67,14 @@ func New(key string) (*Cipher, error) {
 		return nil, fmt.Errorf("cipher: failed to create GCM: %w", err)
 	}
 
-	// Derive HMAC key with explicit domain separation so AES key ≠ HMAC key for the same passphrase.
-	hmacInput := append([]byte("multicast-relay-auth-v1:"), keyBytes...)
-	hmacHash := sha256.Sum256(hmacInput)
-	for i := range hmacInput {
-		hmacInput[i] = 0
-	}
-	for i := range keyBytes {
-		keyBytes[i] = 0
+	// Derive the HMAC key with a distinct salt so AES key ≠ HMAC key for the same passphrase.
+	hmacKey, err := pbkdf2.Key(sha256.New, key, hmacKDFSalt, kdfIterations, kdfKeyLen)
+	if err != nil {
+		return nil, fmt.Errorf("cipher: failed to derive HMAC key: %w", err)
 	}
 
 	c.gcm = gcm
-	c.hmacKey = make([]byte, len(hmacHash))
-	copy(c.hmacKey, hmacHash[:])
-	for i := range hmacHash {
-		hmacHash[i] = 0
-	}
-
+	c.hmacKey = hmacKey
 	c.enabled = true
 	return c, nil
 }

--- a/go/internal/logger/logger.go
+++ b/go/internal/logger/logger.go
@@ -138,8 +138,19 @@ func (l *Logger) Monitor(format string, args ...interface{}) {
 	}
 }
 
+// InfoEnabled reports whether Info-level messages are emitted. Callers on hot
+// paths should guard expensive argument formatting with this check.
+func (l *Logger) InfoEnabled() bool {
+	return l.slog.Enabled(context.Background(), slog.LevelInfo)
+}
+
 // Info logs an informational message (only emitted when verbose is enabled).
+// The format arguments are only evaluated when Info level is enabled, so callers
+// pay no formatting cost in the default (non-verbose) configuration.
 func (l *Logger) Info(format string, args ...interface{}) {
+	if !l.slog.Enabled(context.Background(), slog.LevelInfo) {
+		return
+	}
 	l.slog.Info(fmt.Sprintf(format, args...))
 }
 

--- a/go/internal/relay/packet.go
+++ b/go/internal/relay/packet.go
@@ -62,12 +62,11 @@ func ComputeIPChecksum(data []byte, ipHeaderLength int) []byte {
 	return data
 }
 
-// ComputeUDPChecksum computes the UDP checksum using the pseudo-header.
-// Computes incrementally across pseudo-header, UDP header, and data without concatenation.
-func ComputeUDPChecksum(ipHeader, udpHeader, data []byte) []byte {
-	if len(ipHeader) < 20 || len(udpHeader) < 8 {
-		return udpHeader
-	}
+// udpChecksumValue computes the UDP checksum value over the pseudo-header, UDP
+// header, and data without concatenation. Per RFC 768, a computed checksum of
+// zero is transmitted as all-ones (0xFFFF), since an on-wire 0x0000 signals
+// "checksum not computed."
+func udpChecksumValue(ipHeader, udpHeader, data []byte) uint16 {
 	var sum uint32
 	sum = checksumAdd(sum, ipHeader[12:20])                // src + dst IP
 	sum += uint32(ipHeader[9])                             // protocol
@@ -77,11 +76,47 @@ func ComputeUDPChecksum(ipHeader, udpHeader, data []byte) []byte {
 	sum = checksumAdd(sum, data)
 
 	checksum := checksumFinalize(sum)
+	if checksum == 0 {
+		checksum = 0xffff
+	}
+	return checksum
+}
+
+// ComputeUDPChecksum computes the UDP checksum using the pseudo-header and
+// returns a fresh 8-byte UDP header with the checksum field set.
+func ComputeUDPChecksum(ipHeader, udpHeader, data []byte) []byte {
+	if len(ipHeader) < 20 || len(udpHeader) < 8 {
+		return udpHeader
+	}
+	checksum := udpChecksumValue(ipHeader, udpHeader, data)
 
 	result := make([]byte, 8)
 	copy(result, udpHeader[:6])
 	binary.BigEndian.PutUint16(result[6:8], checksum)
 	return result
+}
+
+// copyIPPayloadRange copies the [start:end) byte range of the virtual
+// concatenation (udpHeader ++ payload) into dst. udpHeader is 8 bytes; bytes at
+// virtual offset < 8 come from udpHeader, the rest from payload. Used to build
+// IP fragments without materializing the full IP payload in a heap buffer.
+func copyIPPayloadRange(dst, udpHeader, payload []byte, start, end int) {
+	n := 0
+	if start < len(udpHeader) {
+		hEnd := end
+		if hEnd > len(udpHeader) {
+			hEnd = len(udpHeader)
+		}
+		n += copy(dst[n:], udpHeader[start:hEnd])
+	}
+	pStart := start - len(udpHeader)
+	if pStart < 0 {
+		pStart = 0
+	}
+	pEnd := end - len(udpHeader)
+	if pEnd > pStart {
+		copy(dst[n:], payload[pStart:pEnd])
+	}
 }
 
 // ModifyUDPPacket modifies the source/destination address and port of a UDP packet.
@@ -142,7 +177,11 @@ func ModifyUDPPacket(data []byte, ipHeaderLength int, newSrc netip.Addr, newSrcP
 // MdnsSetUnicastBit sets the UNICAST-RESPONSE bit in mDNS query packets.
 func MdnsSetUnicastBit(data []byte, ipHeaderLength int) []byte {
 	udpDataStart := ipHeaderLength + 8
-	if len(data) < udpDataStart+4 {
+	// Require the full 12-byte DNS header: flags at [2:4], question count at
+	// [4:6], and the label loop below begins at offset 12. A shorter guard
+	// (e.g. +4) lets a 4- or 5-byte payload reach the udpData[4:6] read and
+	// panic, which would crash the relay on a crafted mDNS packet.
+	if len(data) < udpDataStart+12 {
 		return data
 	}
 	flags := binary.BigEndian.Uint16(data[udpDataStart+2 : udpDataStart+4])

--- a/go/internal/relay/packet_test.go
+++ b/go/internal/relay/packet_test.go
@@ -858,4 +858,81 @@ func TestMdnsSetUnicastBit(t *testing.T) {
 			t.Errorf("class field = 0x%04x, want 0x8001", classField)
 		}
 	})
+
+	t.Run("short payload does not panic", func(t *testing.T) {
+		// A UDP payload shorter than the 12-byte DNS header must be returned
+		// unchanged rather than panicking on the question-count read (udpData[4:6]).
+		for n := 0; n < 12; n++ {
+			dns := make([]byte, n)
+			pkt := buildPacket(dns)
+			result := MdnsSetUnicastBit(pkt, 20)
+			if len(result) != len(pkt) {
+				t.Errorf("payload len %d: expected unchanged packet", n)
+			}
+		}
+	})
+}
+
+func TestCopyIPPayloadRange(t *testing.T) {
+	udpHeader := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	payload := []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	virtual := append(append([]byte{}, udpHeader...), payload...) // 18 bytes
+
+	cases := []struct{ start, end int }{
+		{0, len(virtual)}, // whole datagram (single fragment)
+		{0, 8},            // exactly the UDP header
+		{0, 5},            // partial header
+		{8, len(virtual)}, // payload only (subsequent fragment)
+		{6, 14},           // straddles header/payload boundary
+		{10, 18},          // within payload
+	}
+	for _, c := range cases {
+		dst := make([]byte, c.end-c.start)
+		copyIPPayloadRange(dst, udpHeader, payload, c.start, c.end)
+		if !bytes.Equal(dst, virtual[c.start:c.end]) {
+			t.Errorf("range [%d:%d] = %v, want %v", c.start, c.end, dst, virtual[c.start:c.end])
+		}
+	}
+}
+
+func TestUDPChecksumZeroBecomesFFFF(t *testing.T) {
+	// RFC 768: a computed UDP checksum of 0x0000 must be transmitted as 0xFFFF.
+	ipHeader := make([]byte, 20)
+	ipHeader[9] = 17 // UDP
+	copy(ipHeader[12:16], net.ParseIP("192.168.1.1").To4())
+	copy(ipHeader[16:20], net.ParseIP("192.168.1.2").To4())
+
+	// Search the 2-byte payload space for an input whose raw checksum is zero,
+	// computed the standard way over the pseudo-header. Then assert ComputeUDPChecksum
+	// emits 0xFFFF instead of 0x0000.
+	found := false
+	for v := 0; v <= 0xffff; v++ {
+		payload := []byte{byte(v >> 8), byte(v)}
+		udpLen := 8 + len(payload)
+		udpHeader := make([]byte, 8)
+		binary.BigEndian.PutUint16(udpHeader[4:6], uint16(udpLen))
+
+		pseudo := make([]byte, 0, 12+udpLen)
+		pseudo = append(pseudo, ipHeader[12:20]...) // src+dst
+		pseudo = append(pseudo, 0, 17)              // zero, proto
+		pseudo = append(pseudo, udpHeader[4:6]...)  // udp length
+		pseudo = append(pseudo, udpHeader...)       // udp header (checksum field 0)
+		pseudo = append(pseudo, payload...)
+		raw := NetChecksum(pseudo)
+
+		got := ComputeUDPChecksum(ipHeader, udpHeader, payload)
+		field := binary.BigEndian.Uint16(got[6:8])
+		if field == 0x0000 {
+			t.Errorf("payload 0x%04x: checksum field is 0x0000, must be 0xFFFF", v)
+		}
+		if raw == 0x0000 {
+			found = true
+			if field != 0xffff {
+				t.Errorf("payload 0x%04x: raw checksum 0, field = 0x%04x, want 0xFFFF", v, field)
+			}
+		}
+	}
+	if !found {
+		t.Skip("no zero-checksum payload found in 2-byte space (fixup path not exercised)")
+	}
 }

--- a/go/internal/relay/relay.go
+++ b/go/internal/relay/relay.go
@@ -34,18 +34,37 @@ const (
 
 	// ethPAllBE is ETH_P_ALL in network byte order (big-endian).
 	ethPAllBE = (unix.ETH_P_ALL>>8)&0xff | (unix.ETH_P_ALL&0xff)<<8
+
+	// remoteWriteTimeout bounds a single write to a remote peer inside its writer
+	// goroutine. remoteWriteQueueLen bounds how many frames may be buffered for a
+	// slow peer before new frames are dropped.
+	remoteWriteTimeout  = 100 * time.Millisecond
+	remoteWriteQueueLen = 256
+
+	// arpCacheTTL is how long a resolved IP→MAC mapping is reused before the ARP
+	// table is re-read for SSDP unicast reply routing.
+	arpCacheTTL = 10 * time.Second
 )
 
 const (
 	// maxPacketSize is the maximum expected packet size for pooled buffers.
 	maxPacketSize = 10240
 
+	// maxFrameBufferSize is the largest transmit scratch buffer: a full-size IP
+	// packet plus the 14-byte ethernet header. Pooled buffers are sized to this
+	// so full-size frames never fall outside the pool's capacity.
+	maxFrameBufferSize = 14 + maxPacketSize
+
 	minUDPPacketLen = 28 // min IP(20)+UDP(8) header
 
 	// maxRemoteMessageLen caps the remote TCP framing length prefix. The frame
-	// body is magic(4) + senderIP(4) + packet(<=maxPacketSize), plus GCM
+	// body is seq(8) + magic(4) + senderIP(4) + packet(<=maxPacketSize), plus GCM
 	// nonce(12) + tag(16) when AES is enabled.
-	maxRemoteMessageLen = maxPacketSize + 4 + 4 + 12 + 16
+	maxRemoteMessageLen = maxPacketSize + remoteHeaderLen + 12 + 16
+
+	// remoteHeaderLen is the fixed remote-frame plaintext header preceding the
+	// relayed IP packet: seq(8) + magic(4) + senderIP(4).
+	remoteHeaderLen = 8 + len(magicBytes) + 4
 )
 
 var (
@@ -62,7 +81,7 @@ var (
 	// packetPool provides reusable byte buffers for packet processing.
 	packetPool = sync.Pool{
 		New: func() interface{} {
-			b := make([]byte, 0, maxPacketSize)
+			b := make([]byte, 0, maxFrameBufferSize)
 			return &b
 		},
 	}
@@ -122,7 +141,9 @@ func New(cfg Config) (*PacketRelay, error) {
 		masquerade:           masq,
 		logger:               cfg.Logger,
 		etherAddrs:           make(map[netip.Addr]net.HardwareAddr),
-		remoteReadBufs:       make(map[net.Conn]*remoteReadBuf),
+		remoteWriters:        make(map[net.Conn]*remoteWriter),
+		remotePacketCh:       make(chan remotePacket, 256),
+		remoteFailedCh:       make(chan net.Conn, 16),
 		listenAddr:           cfg.Listen,
 		remotePort:           cfg.RemotePort,
 		remoteRetry:          cfg.RemoteRetry,
@@ -131,7 +152,6 @@ func New(cfg Config) (*PacketRelay, error) {
 		connsDirty:           true,
 		pollDirty:            true,
 		done:                 make(chan struct{}),
-		remoteTmpBuf:         make([]byte, 4096),
 	}
 
 	if cfg.Remote != nil {
@@ -236,12 +256,16 @@ func (pr *PacketRelay) processPacket(data []byte, senderAddr netip.Addr, receivi
 		return
 	}
 
-	// Dedup check FIRST using the original received checksum, before any modification.
+	// Dedup: drop the packet if its IP checksum matches one we recently put on
+	// the wire ourselves (see transmitPacket, which records transmitted
+	// checksums). This suppresses the relay's own retransmissions looping back on
+	// a listening interface. The received checksum is only checked, never
+	// recorded here — recording it would not match the modified packet we later
+	// transmit (e.g. after a TTL or masquerade rewrite).
 	ipChecksum := binary.BigEndian.Uint16(data[10:12])
 	if pr.isDuplicate(ipChecksum) {
 		return
 	}
-	pr.addChecksum(ipChecksum)
 
 	// IP header length
 	ipHeaderLength := int(data[0]&0x0f) * 4
@@ -253,26 +277,25 @@ func (pr *PacketRelay) processPacket(data []byte, senderAddr netip.Addr, receivi
 	remotes := pr.remoteSockets()
 	if len(remotes) > 0 && !(receivingInterface == "remote" && pr.noRemoteRelay) {
 		senderIPBytes := senderAddr.As4()
-		packet := make([]byte, 0, len(magicBytes)+4+len(data))
+		seq := pr.remoteSeq
+		pr.remoteSeq++
+		// Frame plaintext: seq(8) || magic(4) || senderIP(4) || packet.
+		// The sequence number lets the peer reject replayed frames.
+		packet := make([]byte, 0, remoteHeaderLen+len(data))
+		var seqBytes [8]byte
+		binary.BigEndian.PutUint64(seqBytes[:], seq)
+		packet = append(packet, seqBytes[:]...)
 		packet = append(packet, magicBytes[:]...)
 		packet = append(packet, senderIPBytes[:]...)
 		packet = append(packet, data...)
 
 		frame, err := pr.aes.EncryptFrame(packet)
 		if err == nil {
-			var failed []net.Conn
+			// Hand the frame to each connection's writer goroutine instead of
+			// writing inline: a slow or stalled remote peer must never block the
+			// single-threaded event loop and stall local relaying.
 			for _, conn := range remotes {
-				conn.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
-				_, werr := conn.Write(frame)
-				conn.SetWriteDeadline(time.Time{})
-				if werr != nil {
-					pr.logger.Warning("REMOTE: Write error to %s: %s", conn.RemoteAddr(), werr)
-					failed = append(failed, conn)
-				}
-			}
-			for _, conn := range failed {
-				pr.removeConnection(conn)
-				conn.Close()
+				pr.queueRemoteFrame(conn, frame)
 			}
 		}
 	}
@@ -306,6 +329,12 @@ func (pr *PacketRelay) processPacket(data []byte, senderAddr netip.Addr, receivi
 	broadcastPacket := false
 	if receivingInterface == "local" {
 		receivingInterface, broadcastPacket = pr.findReceivingIface(senderAddr, origDstAddr, origDstPort)
+	} else if receivingInterface == "remote" {
+		// A broadcast packet arriving over the remote relay carries the sending
+		// site's subnet broadcast as its destination, which never equals any
+		// local interface's broadcast. Recognize it here so it can be re-broadcast
+		// onto local interfaces instead of being silently dropped.
+		broadcastPacket = pr.isRemoteBroadcast(origDstAddr, origDstPort)
 	}
 
 	// Relay to all other interfaces
@@ -341,32 +370,38 @@ func (pr *PacketRelay) processPacket(data []byte, senderAddr netip.Addr, receivi
 				continue
 			}
 
-			txBp := getBuffer(len(data))
-			txData := *txBp
-			copy(txData, data)
-
+			// Only take a private copy when masquerading rewrites the source
+			// address; otherwise transmitPacket reads data without mutating it, so
+			// the received buffer can be passed through directly.
 			isMasq := pr.masquerade[tx.Interface]
+			txData := data
+			var txBp *[]byte
 			if isMasq {
+				txBp = getBuffer(len(data))
+				txData = *txBp
+				copy(txData, data)
 				addrBytes := tx.Addr.As4()
 				copy(txData[12:16], addrBytes[:])
 			}
 
-			servicePrefix := ""
-			if tx.Service != "" {
-				servicePrefix = fmt.Sprintf("[%s] ", tx.Service)
+			if pr.logger.InfoEnabled() {
+				servicePrefix := ""
+				if tx.Service != "" {
+					servicePrefix = fmt.Sprintf("[%s] ", tx.Service)
+				}
+				action := "Relayed"
+				if isMasq {
+					action = "Masqueraded"
+				}
+				plural := "s"
+				if len(txData) == 1 {
+					plural = ""
+				}
+				pr.logger.Info("%s%s %d byte%s from %s:%d on %s [ttl %d] to %s:%d via %s/%s",
+					servicePrefix, action, len(txData), plural,
+					srcAddr, srcPort, receivingInterface, ttl,
+					localDstAddr, dstPort, tx.Interface, tx.Addr)
 			}
-			action := "Relayed"
-			if isMasq {
-				action = "Masqueraded"
-			}
-			plural := "s"
-			if len(txData) == 1 {
-				plural = ""
-			}
-			pr.logger.Info("%s%s %d byte%s from %s:%d on %s [ttl %d] to %s:%d via %s/%s",
-				servicePrefix, action, len(txData), plural,
-				srcAddr, srcPort, receivingInterface, ttl,
-				localDstAddr, dstPort, tx.Interface, tx.Addr)
 
 			if err := pr.transmitPacket(tx, localDestMac, ipHeaderLength, txData); err != nil {
 				// Try to recover if ENXIO (device not configured)
@@ -376,7 +411,9 @@ func (pr *PacketRelay) processPacket(data []byte, senderAddr netip.Addr, receivi
 					pr.logger.Warning("Error sending packet: %s", err)
 				}
 			}
-			putBuffer(txBp)
+			if txBp != nil {
+				putBuffer(txBp)
+			}
 		}
 	}
 }
@@ -419,20 +456,40 @@ func (pr *PacketRelay) handleSSDP(data []byte, ipHeaderLength int, srcAddr netip
 
 		outData = ModifyUDPPacket(data, ipHeaderLength, netip.Addr{}, 0, outDstAddr, outDstPort)
 
-		macStr, err := UnicastIPToMAC(outDstAddr.String(), "")
-		if err != nil || macStr == "" {
+		destMac, err := pr.resolveUnicastMAC(outDstAddr)
+		if err != nil || destMac == nil {
 			pr.logger.Info("Could not resolve MAC for %s", outDstAddr)
 			drop = true
-			return
+			return outData, outSrcAddr, outSrcPort, outDstAddr, outDstPort, nil, true
 		}
-		destMac, err = net.ParseMAC(macStr)
-		if err != nil {
-			pr.logger.Info("Could not parse MAC %s: %s", macStr, err)
-			drop = true
-			return
-		}
+		return outData, outSrcAddr, outSrcPort, outDstAddr, outDstPort, destMac, false
 	}
 	return
+}
+
+// resolveUnicastMAC resolves an IP to a MAC via the ARP table, caching the most
+// recent lookup for a short TTL. SSDP unicast replies arrive in bursts to the
+// same source, so this avoids re-reading and re-parsing /proc/net/arp per packet.
+// Called only from the main loop goroutine.
+func (pr *PacketRelay) resolveUnicastMAC(ip netip.Addr) (net.HardwareAddr, error) {
+	ipStr := ip.String()
+	now := time.Now()
+	if pr.arpCacheMAC != nil && pr.arpCacheIP == ipStr && now.Sub(pr.arpCacheTime) < arpCacheTTL {
+		return pr.arpCacheMAC, nil
+	}
+	macStr, err := UnicastIPToMAC(ipStr, "")
+	if err != nil || macStr == "" {
+		return nil, err
+	}
+	mac, err := net.ParseMAC(macStr)
+	if err != nil {
+		pr.logger.Info("Could not parse MAC %s: %s", macStr, err)
+		return nil, err
+	}
+	pr.arpCacheIP = ipStr
+	pr.arpCacheMAC = mac
+	pr.arpCacheTime = now
+	return mac, nil
 }
 
 // findReceivingIface identifies which local interface received a packet based on destination.
@@ -446,6 +503,74 @@ func (pr *PacketRelay) findReceivingIface(senderAddr, origDstAddr netip.Addr, or
 		}
 	}
 	return
+}
+
+// isRemoteBroadcast reports whether a packet arriving over the remote relay is a
+// broadcast that should be re-broadcast onto local interfaces. Remote packets are
+// only ever forwarded because they matched a relay rule on the sender, so any
+// non-multicast packet whose destination port matches a configured broadcast
+// transmitter (Relay.Addr == the interface broadcast) is a relayed broadcast.
+func (pr *PacketRelay) isRemoteBroadcast(origDstAddr netip.Addr, origDstPort uint16) bool {
+	if origDstAddr.IsMulticast() {
+		return false
+	}
+	for i := range pr.transmitters {
+		tx := &pr.transmitters[i]
+		if int(origDstPort) == tx.Relay.Port && tx.Relay.Addr == tx.Broadcast {
+			return true
+		}
+	}
+	return false
+}
+
+// queueRemoteFrame hands a wire frame to the connection's writer goroutine via a
+// bounded queue. If the queue is full (a slow or stalled peer), the frame is
+// dropped rather than blocking the event loop — discovery traffic tolerates loss.
+// The writer goroutine is created lazily on first use. Called only from the main
+// loop goroutine, so remoteWriters access needs no locking.
+func (pr *PacketRelay) queueRemoteFrame(conn net.Conn, frame []byte) {
+	w := pr.remoteWriters[conn]
+	if w == nil {
+		w = &remoteWriter{conn: conn, ch: make(chan []byte, remoteWriteQueueLen), done: make(chan struct{})}
+		pr.remoteWriters[conn] = w
+		go pr.runWriter(w)
+	}
+	select {
+	case w.ch <- frame:
+	default:
+		pr.logger.Info("REMOTE: Write queue full for %s — dropping frame", conn.RemoteAddr())
+	}
+}
+
+// runWriter drains a connection's frame queue and writes frames to the socket.
+// On a write error it closes the connection; the main loop's reader observes the
+// closure and cleans up. Exits when the connection is removed or the relay stops.
+func (pr *PacketRelay) runWriter(w *remoteWriter) {
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-pr.done:
+			return
+		case frame := <-w.ch:
+			w.conn.SetWriteDeadline(time.Now().Add(remoteWriteTimeout))
+			_, err := w.conn.Write(frame)
+			w.conn.SetWriteDeadline(time.Time{})
+			if err != nil {
+				w.conn.Close()
+				return
+			}
+		}
+	}
+}
+
+// stopWriter tears down a connection's writer goroutine, if any.
+// Called only from the main loop goroutine.
+func (pr *PacketRelay) stopWriter(conn net.Conn) {
+	if w := pr.remoteWriters[conn]; w != nil {
+		close(w.done)
+		delete(pr.remoteWriters, conn)
+	}
 }
 
 // isDuplicate checks whether this checksum was recently seen.

--- a/go/internal/relay/relay_loop.go
+++ b/go/internal/relay/relay_loop.go
@@ -11,6 +11,14 @@ import (
 func (pr *PacketRelay) Loop() error {
 	buf := make([]byte, maxPacketSize)
 
+	// When remote relay is active, remote TCP connections are serviced once per
+	// loop iteration, so a shorter poll timeout bounds remote packet latency when
+	// the box is otherwise idle. Poll still wakes immediately on local traffic.
+	pollTimeoutMs := 1000
+	if len(pr.remoteAddrs) > 0 || len(pr.listenAddr) > 0 {
+		pollTimeoutMs = 100
+	}
+
 	for {
 		select {
 		case <-pr.done:
@@ -44,6 +52,7 @@ func (pr *PacketRelay) Loop() error {
 					} else {
 						result.ra.Conn = result.conn
 						pr.connsDirty = true
+						pr.startReader(result.conn)
 						pr.logger.Info("REMOTE: Connection to %s established", result.ra.Addr)
 					}
 				default:
@@ -60,6 +69,7 @@ func (pr *PacketRelay) Loop() error {
 				case conn := <-pr.acceptCh:
 					pr.remoteConnections = append(pr.remoteConnections, conn)
 					pr.connsDirty = true
+					pr.startReader(conn)
 					pr.logger.Info("REMOTE: Accepted connection from %s", conn.RemoteAddr())
 				default:
 					break drainAccept
@@ -67,15 +77,15 @@ func (pr *PacketRelay) Loop() error {
 			}
 		}
 
-		// Read from remote TCP connections
-		pr.readRemoteConnections()
+		// Process packets decoded by remote reader goroutines.
+		pr.drainRemotePackets()
 
 		// Clear revents before polling
 		for i := range pr.pollFds {
 			pr.pollFds[i].Revents = 0
 		}
 
-		n, err := unix.Poll(pr.pollFds, 1000) // 1 second timeout
+		n, err := unix.Poll(pr.pollFds, pollTimeoutMs)
 		if err != nil {
 			if err == unix.EINTR {
 				continue
@@ -91,7 +101,9 @@ func (pr *PacketRelay) Loop() error {
 				continue
 			}
 
-			// Local receiver
+			// Local receiver. processPacket runs synchronously and copies whatever
+			// it needs to retain, so buf can be passed directly without a defensive
+			// copy into a pooled buffer.
 			nread, from, err := unix.Recvfrom(int(pfd.Fd), buf, 0)
 			if err != nil {
 				pr.logger.Warning("Error receiving packet: %s", err)
@@ -101,18 +113,12 @@ func (pr *PacketRelay) Loop() error {
 				continue
 			}
 
-			dataBp := getBuffer(nread)
-			copy(*dataBp, buf[:nread])
-
 			sa, ok := from.(*unix.SockaddrInet4)
 			if !ok {
-				putBuffer(dataBp)
 				continue
 			}
 			senderAddr := AddrFrom4Bytes(sa.Addr[:])
-
-			pr.processPacket(*dataBp, senderAddr, "local")
-			putBuffer(dataBp)
+			pr.processPacket(buf[:nread], senderAddr, "local")
 		}
 	}
 }

--- a/go/internal/relay/relay_remote.go
+++ b/go/internal/relay/relay_remote.go
@@ -8,98 +8,136 @@ import (
 	"time"
 )
 
-// remoteReadBuf is defined in relay_types.go.
+// startReader launches the per-connection reader goroutine. Reading in a
+// dedicated goroutine keeps blocking reads off the single-threaded event loop:
+// a slow or idle remote peer can never stall local relaying.
+func (pr *PacketRelay) startReader(conn net.Conn) {
+	go pr.runReader(conn)
+}
 
-// readRemoteConnections does non-blocking reads from all remote TCP connections
-// and processes any complete messages.
-func (pr *PacketRelay) readRemoteConnections() {
-	remotes := pr.remoteSockets()
-	if len(remotes) == 0 {
-		return
-	}
+// runReader reads length-prefixed frames from a single remote connection,
+// decrypts and validates them, and delivers decoded packets to the main loop via
+// remotePacketCh. On any fatal error it reports the connection on remoteFailedCh
+// and exits. It owns all per-connection read state, so no locking is needed.
+func (pr *PacketRelay) runReader(conn net.Conn) {
+	var buf []byte
+	msgLen := -1
+	var lastSeq uint64
+	var seqSet bool
+	tmp := make([]byte, 4096)
 
-	var failed []net.Conn
-	for _, conn := range remotes {
-		rb, ok := pr.remoteReadBufs[conn]
-		if !ok {
-			rb = &remoteReadBuf{msgLen: -1, lastActive: time.Now()}
-			pr.remoteReadBufs[conn] = rb
-		}
-
-		conn.SetReadDeadline(time.Now().Add(5 * time.Millisecond))
-
-		for {
-			n, err := conn.Read(pr.remoteTmpBuf)
-			if n > 0 {
-				rb.buf.Write(pr.remoteTmpBuf[:n])
-				rb.lastActive = time.Now()
-			}
-			if err != nil {
-				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-					break
-				}
-				pr.logger.Warning("REMOTE: Read error from %s: %s", conn.RemoteAddr(), err)
-				failed = append(failed, conn)
-				break
-			}
-			if n == 0 {
-				break
-			}
-		}
-
-		// Process complete messages from the buffer.
-		for {
-			if rb.msgLen < 0 {
-				if rb.buf.Len() < 2 {
-					break
-				}
-				rb.msgLen = int(binary.BigEndian.Uint16(rb.buf.Bytes()[:2]))
-				rb.buf.Next(2)
-				if rb.msgLen > maxRemoteMessageLen {
-					pr.logger.Warning("REMOTE: Message too large (%d bytes) from %s — closing", rb.msgLen, conn.RemoteAddr())
-					failed = append(failed, conn)
-					break
-				}
-			}
-			if rb.buf.Len() < rb.msgLen {
-				if time.Since(rb.lastActive) > 10*time.Second {
-					pr.logger.Warning("REMOTE: Stale connection from %s (partial message timeout) — closing", conn.RemoteAddr())
-					failed = append(failed, conn)
-				}
-				break
-			}
-
-			encrypted := rb.buf.Next(rb.msgLen)
-			rb.msgLen = -1
-
-			decrypted, err := pr.aes.Decrypt(encrypted)
-			if err != nil {
-				pr.logger.Warning("REMOTE: Decrypt error from %s — closing", conn.RemoteAddr())
-				failed = append(failed, conn)
-				break
-			}
-
-			if len(decrypted) < len(magicBytes)+4+minUDPPacketLen {
-				pr.logger.Info("REMOTE: Packet too short from %s", conn.RemoteAddr())
-				continue
-			}
-			if decrypted[0] != magicBytes[0] || decrypted[1] != magicBytes[1] ||
-				decrypted[2] != magicBytes[2] || decrypted[3] != magicBytes[3] {
-				pr.logger.Info("REMOTE: Invalid magic bytes from %s", conn.RemoteAddr())
-				continue
-			}
-
-			senderAddr := AddrFrom4Bytes(decrypted[4:8])
-			packetData := decrypted[8:]
-
-			pr.processPacket(packetData, senderAddr, "remote")
+	fail := func() {
+		select {
+		case pr.remoteFailedCh <- conn:
+		case <-pr.done:
 		}
 	}
 
-	for _, conn := range failed {
-		delete(pr.remoteReadBufs, conn)
-		pr.removeConnection(conn)
-		conn.Close()
+	for {
+		select {
+		case <-pr.done:
+			return
+		default:
+		}
+
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			for {
+				if msgLen < 0 {
+					if len(buf) < 2 {
+						break
+					}
+					msgLen = int(binary.BigEndian.Uint16(buf[:2]))
+					buf = buf[2:]
+					if msgLen > maxRemoteMessageLen {
+						pr.logger.Warning("REMOTE: Message too large (%d bytes) from %s — closing", msgLen, conn.RemoteAddr())
+						fail()
+						return
+					}
+				}
+				if len(buf) < msgLen {
+					break
+				}
+				encrypted := buf[:msgLen]
+				buf = buf[msgLen:]
+				msgLen = -1
+
+				if !pr.deliverRemoteFrame(conn, encrypted, &lastSeq, &seqSet) {
+					fail()
+					return
+				}
+			}
+			// Reclaim the consumed prefix so buf does not grow unbounded.
+			if len(buf) == 0 {
+				buf = buf[:0]
+			}
+		}
+		if err != nil {
+			fail()
+			return
+		}
+	}
+}
+
+// deliverRemoteFrame decrypts and validates a single frame and, if valid, sends
+// the decoded packet to the main loop. It returns false only on a fatal error
+// that should close the connection (decrypt failure); malformed-but-nonfatal
+// frames are logged and skipped (returning true).
+func (pr *PacketRelay) deliverRemoteFrame(conn net.Conn, encrypted []byte, lastSeq *uint64, seqSet *bool) bool {
+	decrypted, err := pr.aes.Decrypt(encrypted)
+	if err != nil {
+		pr.logger.Warning("REMOTE: Decrypt error from %s — closing", conn.RemoteAddr())
+		return false
+	}
+
+	if len(decrypted) < remoteHeaderLen+minUDPPacketLen {
+		pr.logger.Info("REMOTE: Packet too short from %s", conn.RemoteAddr())
+		return true
+	}
+	// Frame plaintext: seq(8) || magic(4) || senderIP(4) || packet.
+	seq := binary.BigEndian.Uint64(decrypted[0:8])
+	if decrypted[8] != magicBytes[0] || decrypted[9] != magicBytes[1] ||
+		decrypted[10] != magicBytes[2] || decrypted[11] != magicBytes[3] {
+		pr.logger.Info("REMOTE: Invalid magic bytes from %s", conn.RemoteAddr())
+		return true
+	}
+	// Replay protection: reject frames whose sequence number does not advance.
+	// Gaps are allowed (a frame may be dropped by a full write queue), but a
+	// repeated or older sequence is a replay.
+	if *seqSet && seq <= *lastSeq {
+		pr.logger.Info("REMOTE: Dropping replayed frame (seq %d <= %d) from %s", seq, *lastSeq, conn.RemoteAddr())
+		return true
+	}
+	*lastSeq = seq
+	*seqSet = true
+
+	senderAddr := AddrFrom4Bytes(decrypted[12:16])
+	// Copy the packet: decrypted may alias reused read state, and processPacket
+	// (which runs later on the main loop) mutates the buffer in place.
+	pkt := make([]byte, len(decrypted)-16)
+	copy(pkt, decrypted[16:])
+
+	select {
+	case pr.remotePacketCh <- remotePacket{senderAddr: senderAddr, data: pkt}:
+	case <-pr.done:
+	}
+	return true
+}
+
+// drainRemotePackets processes packets decoded by reader goroutines and cleans up
+// failed connections. Called from the main loop.
+func (pr *PacketRelay) drainRemotePackets() {
+	for {
+		select {
+		case rp := <-pr.remotePacketCh:
+			pr.processPacket(rp.data, rp.senderAddr, "remote")
+		case conn := <-pr.remoteFailedCh:
+			pr.removeConnection(conn)
+			conn.Close()
+		default:
+			return
+		}
 	}
 }
 
@@ -148,16 +186,42 @@ func (pr *PacketRelay) dialRemote(ra *RemoteAddr) {
 
 	if pr.aes.Enabled() {
 		conn.SetDeadline(time.Now().Add(5 * time.Second))
-		challenge := make([]byte, 16)
-		if _, err := io.ReadFull(conn, challenge); err != nil {
+
+		// 1. Answer the server's challenge to prove we know the key.
+		serverChallenge := make([]byte, 16)
+		if _, err := io.ReadFull(conn, serverChallenge); err != nil {
 			conn.Close()
 			pr.sendConnectResult(connectResult{ra: ra, err: fmt.Errorf("auth challenge: %w", err)})
 			return
 		}
-		response := pr.aes.Respond(challenge)
-		if _, err := conn.Write(response); err != nil {
+		if _, err := conn.Write(pr.aes.Respond(serverChallenge)); err != nil {
 			conn.Close()
 			pr.sendConnectResult(connectResult{ra: ra, err: fmt.Errorf("auth response: %w", err)})
+			return
+		}
+
+		// 2. Challenge the server in return and verify it knows the key, so we
+		// never relay to an impostor endpoint (mutual authentication).
+		clientChallenge, err := pr.aes.Challenge()
+		if err != nil {
+			conn.Close()
+			pr.sendConnectResult(connectResult{ra: ra, err: fmt.Errorf("auth challenge gen: %w", err)})
+			return
+		}
+		if _, err := conn.Write(clientChallenge); err != nil {
+			conn.Close()
+			pr.sendConnectResult(connectResult{ra: ra, err: fmt.Errorf("auth challenge send: %w", err)})
+			return
+		}
+		serverResponse := make([]byte, 32)
+		if _, err := io.ReadFull(conn, serverResponse); err != nil {
+			conn.Close()
+			pr.sendConnectResult(connectResult{ra: ra, err: fmt.Errorf("server auth read: %w", err)})
+			return
+		}
+		if !pr.aes.Verify(clientChallenge, serverResponse) {
+			conn.Close()
+			pr.sendConnectResult(connectResult{ra: ra, err: fmt.Errorf("server authentication failed — wrong key")})
 			return
 		}
 		conn.SetDeadline(time.Time{})
@@ -179,9 +243,11 @@ func (pr *PacketRelay) sendConnectResult(res connectResult) {
 	}
 }
 
-// removeConnection removes a remote connection from the active set and cleans up its read buffer.
+// removeConnection removes a remote connection from the active set and stops its
+// writer goroutine. The reader goroutine exits on its own once the connection is
+// closed by the caller.
 func (pr *PacketRelay) removeConnection(conn net.Conn) {
-	delete(pr.remoteReadBufs, conn)
+	pr.stopWriter(conn)
 	pr.connsDirty = true
 	for i, c := range pr.remoteConnections {
 		if c == conn {
@@ -226,32 +292,48 @@ func (pr *PacketRelay) acceptLoop() {
 			continue
 		}
 
-		// HMAC challenge-response: send 16-byte nonce, expect HMAC-SHA256 response.
-		// Only active when encryption (and therefore a shared key) is configured.
+		// Mutual HMAC challenge-response authentication (only when a shared key is
+		// configured). The server proves the client knows the key AND proves its
+		// own knowledge of the key to the client, so neither side trusts an
+		// unauthenticated peer.
 		if pr.aes.Enabled() {
-			challenge, err := pr.aes.Challenge()
+			conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+			// 1. Challenge the client and verify its response.
+			serverChallenge, err := pr.aes.Challenge()
 			if err != nil {
 				pr.logger.Warning("REMOTE: Challenge generation failed: %s", err)
 				conn.Close()
 				continue
 			}
-			conn.SetDeadline(time.Now().Add(5 * time.Second))
-			if _, err := conn.Write(challenge); err != nil {
+			if _, err := conn.Write(serverChallenge); err != nil {
 				conn.Close()
 				continue
 			}
-			response := make([]byte, 32)
-			if _, err := io.ReadFull(conn, response); err != nil {
+			clientResponse := make([]byte, 32)
+			if _, err := io.ReadFull(conn, clientResponse); err != nil {
 				pr.logger.Warning("REMOTE: Auth handshake failed from %s", remoteIP)
 				conn.Close()
 				continue
 			}
-			conn.SetDeadline(time.Time{})
-			if !pr.aes.Verify(challenge, response) {
+			if !pr.aes.Verify(serverChallenge, clientResponse) {
 				pr.logger.Warning("REMOTE: Auth rejected from %s — wrong key", remoteIP)
 				conn.Close()
 				continue
 			}
+
+			// 2. Answer the client's challenge to prove our identity.
+			clientChallenge := make([]byte, 16)
+			if _, err := io.ReadFull(conn, clientChallenge); err != nil {
+				pr.logger.Warning("REMOTE: Auth handshake failed from %s", remoteIP)
+				conn.Close()
+				continue
+			}
+			if _, err := conn.Write(pr.aes.Respond(clientChallenge)); err != nil {
+				conn.Close()
+				continue
+			}
+			conn.SetDeadline(time.Time{})
 		}
 
 		pr.acceptCh <- conn

--- a/go/internal/relay/relay_socket.go
+++ b/go/internal/relay/relay_socket.go
@@ -208,16 +208,31 @@ func resolveInterface(spec string) (*InterfaceResult, error) {
 	return nil, fmt.Errorf("interface %s not found", spec)
 }
 
-// getInterface resolves an interface spec and optionally waits for an IPv4 address.
+// getInterface resolves an interface spec, waiting for an IPv4 address if the
+// --wait option is configured. This may block and is only safe to call during
+// startup, before the event loop runs.
 func (pr *PacketRelay) getInterface(iface string) (*InterfaceResult, error) {
+	return pr.resolveInterfaceWait(iface, pr.wait)
+}
+
+// resolveInterfaceWait resolves an interface spec. When wait is true it blocks
+// (checking pr.done) until the interface has an IPv4 address. Callers on the
+// event-loop goroutine (e.g. transmitter recovery) must pass wait=false so a
+// missing address cannot stall the entire relay.
+func (pr *PacketRelay) resolveInterfaceWait(iface string, wait bool) (*InterfaceResult, error) {
 	result, err := resolveInterface(iface)
 	if err != nil {
 		return nil, err
 	}
 
 	// Wait for IPv4 address if configured
-	if pr.wait && !result.Addr.IsValid() {
+	if wait && !result.Addr.IsValid() {
 		for {
+			select {
+			case <-pr.done:
+				return nil, fmt.Errorf("shutting down while waiting for IPv4 address on %s", result.Name)
+			default:
+			}
 			pr.logger.Info("Waiting for IPv4 address on %s", result.Name)
 			time.Sleep(time.Second)
 			result, err = resolveInterface(result.Name)
@@ -248,7 +263,9 @@ func (pr *PacketRelay) getInterface(iface string) (*InterfaceResult, error) {
 // recoverTransmitter attempts to re-create the transmit socket after ENXIO.
 func (pr *PacketRelay) recoverTransmitter(tx *Transmitter, destMac net.HardwareAddr, ipHeaderLength int, data []byte) {
 	pr.logger.Info("Attempting to recover interface %s", tx.Interface)
-	ifInfo, err := pr.getInterface(tx.Interface)
+	// Never wait here: recovery runs on the event-loop goroutine, so blocking
+	// on a missing IPv4 address would stall all relaying and clean shutdown.
+	ifInfo, err := pr.resolveInterfaceWait(tx.Interface, false)
 	if err != nil {
 		pr.logger.Warning("Recovery failed for %s: %s", tx.Interface, err)
 		return
@@ -279,36 +296,39 @@ func (pr *PacketRelay) transmitPacket(tx *Transmitter, destMac net.HardwareAddr,
 
 	dontFragment := (data[6] & 0x40) >> 6
 
-	udpHeader = ComputeUDPChecksum(ipHeader, udpHeader, payload)
+	// Recompute the UDP checksum into a local 8-byte header (no heap allocation).
+	// The IP payload to fragment is the virtual concatenation of newUDPHeader and payload.
+	var newUDPHeader [8]byte
+	copy(newUDPHeader[:], udpHeader[:6])
+	binary.BigEndian.PutUint16(newUDPHeader[6:8], udpChecksumValue(ipHeader, udpHeader, payload))
 
 	hasEther := !bytes.Equal(tx.MAC, zeroMAC)
 
-	// The IP payload is UDP header + UDP data. For fragmentation purposes,
-	// we fragment the entire IP payload (transport header + data).
-	ipPayload := make([]byte, 0, 8+len(payload))
-	ipPayload = append(ipPayload, udpHeader...)
-	ipPayload = append(ipPayload, payload...)
+	ipPayloadLen := 8 + len(payload)
 
 	// Get a scratch buffer large enough for the largest frame: 14 (ether) + IP header + max fragment
-	maxFrameSize := 14 + ipHeaderLength + len(ipPayload)
+	maxFrameSize := 14 + ipHeaderLength + ipPayloadLen
 	scratchBp := getBuffer(maxFrameSize)
 	defer putBuffer(scratchBp)
 	scratch := *scratchBp
 
-	for boundary := 0; boundary < len(ipPayload); boundary += udpMaxLength {
+	for boundary := 0; boundary < ipPayloadLen; boundary += udpMaxLength {
 		end := boundary + udpMaxLength
-		if end > len(ipPayload) {
-			end = len(ipPayload)
+		if end > ipPayloadLen {
+			end = ipPayloadLen
 		}
-		fragment := ipPayload[boundary:end]
-		totalLength := ipHeaderLength + len(fragment)
-		moreFragments := end < len(ipPayload)
+		fragLen := end - boundary
+		totalLength := ipHeaderLength + fragLen
+		moreFragments := end < ipPayloadLen
 
 		// Fragment offset is in 8-byte units per RFC 791
 		flagsOffset := uint16((boundary / 8) & 0x1fff)
 		if moreFragments {
 			flagsOffset |= 0x2000
-		} else if dontFragment != 0 {
+		} else if dontFragment != 0 && boundary == 0 {
+			// Only preserve the Don't-Fragment bit when the datagram fit in a
+			// single fragment. Stamping DF on the tail of a fragment train would
+			// be self-contradictory.
 			flagsOffset |= 0x4000
 		}
 
@@ -323,11 +343,18 @@ func (pr *PacketRelay) transmitPacket(tx *Transmitter, destMac net.HardwareAddr,
 		binary.BigEndian.PutUint16(scratch[etherOff+2:etherOff+4], uint16(totalLength))
 		binary.BigEndian.PutUint16(scratch[etherOff+6:etherOff+8], flagsOffset)
 
-		// Append the fragment data (first fragment includes UDP header, subsequent don't)
-		copy(scratch[etherOff+ipHeaderLength:], fragment)
+		// Copy the fragment data directly from the virtual [newUDPHeader || payload]
+		// range, so the first fragment includes the UDP header and later ones don't.
+		copyIPPayloadRange(scratch[etherOff+ipHeaderLength:], newUDPHeader[:], payload, boundary, end)
 
 		ipPacket := scratch[etherOff : etherOff+totalLength]
 		ComputeIPChecksum(ipPacket, ipHeaderLength)
+
+		// Record the transmitted IP checksum so the relay recognizes this packet
+		// when it loops back on its own listening interface. The dedup ring must
+		// hold the checksum that actually goes on the wire (post TTL/masquerade/
+		// SSDP rewrite), not the pre-modification checksum of the received packet.
+		pr.addChecksum(binary.BigEndian.Uint16(ipPacket[10:12]))
 
 		var frame []byte
 		if hasEther {
@@ -357,9 +384,13 @@ func interfaceIndex(name string) (int, error) {
 	return iface.Index, nil
 }
 
-// createTransmitSocket creates and binds an AF_PACKET raw socket for the named interface.
+// createTransmitSocket creates and binds a send-only AF_PACKET raw socket for the
+// named interface. The socket protocol is 0 (rather than ETH_P_ALL): these sockets
+// are only ever written to, never read or polled, so binding them to ETH_P_ALL
+// would needlessly install a kernel receive tap that clones every packet in and
+// out of the interface into a queue that is never drained.
 func createTransmitSocket(ifName string) (int, error) {
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, ethPAllBE)
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, 0)
 	if err != nil {
 		return 0, fmt.Errorf("cannot create transmit socket for %s: %w", ifName, err)
 	}
@@ -369,7 +400,7 @@ func createTransmitSocket(ifName string) (int, error) {
 		return 0, fmt.Errorf("cannot get interface index for %s: %w", ifName, err)
 	}
 	sa := &unix.SockaddrLinklayer{
-		Protocol: uint16(ethPAllBE),
+		Protocol: 0,
 		Ifindex:  ifIndex,
 	}
 	if err := unix.Bind(fd, sa); err != nil {

--- a/go/internal/relay/relay_test.go
+++ b/go/internal/relay/relay_test.go
@@ -397,7 +397,7 @@ func newTestLogger(t *testing.T) *logger.Logger {
 
 func TestRemoveConnectionFromRemoteConnections(t *testing.T) {
 	pr := &PacketRelay{
-		remoteReadBufs: make(map[net.Conn]*remoteReadBuf),
+		remoteWriters: make(map[net.Conn]*remoteWriter),
 	}
 
 	// Create a pair of connected pipes to use as mock connections
@@ -410,8 +410,6 @@ func TestRemoveConnectionFromRemoteConnections(t *testing.T) {
 	defer client2.Close()
 
 	pr.remoteConnections = []net.Conn{server, server2}
-	pr.remoteReadBufs[server] = &remoteReadBuf{msgLen: -1}
-	pr.remoteReadBufs[server2] = &remoteReadBuf{msgLen: -1}
 
 	pr.removeConnection(server)
 
@@ -421,14 +419,11 @@ func TestRemoveConnectionFromRemoteConnections(t *testing.T) {
 	if pr.remoteConnections[0] != server2 {
 		t.Error("wrong connection removed")
 	}
-	if _, ok := pr.remoteReadBufs[server]; ok {
-		t.Error("read buffer for removed connection should be deleted")
-	}
 }
 
 func TestRemoveConnectionFromRemoteAddrs(t *testing.T) {
 	pr := &PacketRelay{
-		remoteReadBufs: make(map[net.Conn]*remoteReadBuf),
+		remoteWriters: make(map[net.Conn]*remoteWriter),
 	}
 
 	server, client := net.Pipe()
@@ -448,154 +443,207 @@ func TestRemoveConnectionFromRemoteAddrs(t *testing.T) {
 	}
 }
 
+func TestIsRemoteBroadcast(t *testing.T) {
+	pr := &PacketRelay{
+		transmitters: []Transmitter{
+			{ // broadcast transmitter: Relay.Addr == Broadcast
+				Relay:     RelayAddr{Addr: netip.MustParseAddr("192.168.2.255"), Port: 6969},
+				Broadcast: netip.MustParseAddr("192.168.2.255"),
+			},
+			{ // multicast transmitter: Relay.Addr != Broadcast
+				Relay:     RelayAddr{Addr: netip.MustParseAddr("239.255.255.250"), Port: 1900},
+				Broadcast: netip.MustParseAddr("192.168.2.255"),
+			},
+		},
+	}
+
+	// A broadcast from another site on the broadcast relay port is recognized.
+	if !pr.isRemoteBroadcast(netip.MustParseAddr("192.168.1.255"), 6969) {
+		t.Error("expected remote broadcast on port 6969 to be recognized")
+	}
+	// A multicast destination is never a broadcast.
+	if pr.isRemoteBroadcast(netip.MustParseAddr("239.255.255.250"), 1900) {
+		t.Error("multicast destination must not be treated as broadcast")
+	}
+	// A port with no broadcast transmitter is not a broadcast.
+	if pr.isRemoteBroadcast(netip.MustParseAddr("192.168.1.255"), 1234) {
+		t.Error("unmatched port must not be treated as broadcast")
+	}
+}
+
 // --- Remote relay protocol tests ---
 
-func TestReadRemoteConnections(t *testing.T) {
-	log := newTestLogger(t)
-	aes, err := cipher.New("")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pr := &PacketRelay{
-		logger:         log,
-		aes:            aes,
-		noRemoteRelay:  true, // prevent processPacket from writing back to remotes
-		connsDirty:     true,
-		remoteReadBufs: make(map[net.Conn]*remoteReadBuf),
-		remoteTmpBuf:   make([]byte, 4096),
-	}
-
-	// Create a pipe to simulate a remote connection
-	server, client := net.Pipe()
-	defer server.Close()
-	defer client.Close()
-
-	pr.remoteConnections = []net.Conn{server}
-
-	// Build a valid remote relay message: 2-byte length + magic + senderIP + packet
-	// Minimum packet is 28 bytes (20 IP header + 8 UDP header)
+// minUDPTestPacket builds a minimal 28-byte IPv4/UDP packet for remote-frame tests.
+func minUDPTestPacket(src, dst string, sport, dport uint16) []byte {
 	ipHeader := make([]byte, 20)
 	ipHeader[0] = 0x45 // version 4, IHL 5
 	ipHeader[8] = 64   // TTL
 	ipHeader[9] = 17   // UDP protocol
-	copy(ipHeader[12:16], net.ParseIP("192.168.1.100").To4())
-	copy(ipHeader[16:20], net.ParseIP("239.255.255.250").To4())
+	copy(ipHeader[12:16], net.ParseIP(src).To4())
+	copy(ipHeader[16:20], net.ParseIP(dst).To4())
 	binary.BigEndian.PutUint16(ipHeader[2:4], 28) // total length
 
 	udpHeader := make([]byte, 8)
-	binary.BigEndian.PutUint16(udpHeader[0:2], 1234) // src port
-	binary.BigEndian.PutUint16(udpHeader[2:4], 1900) // dst port
-	binary.BigEndian.PutUint16(udpHeader[4:6], 8)    // udp length
-
-	packetData := append(ipHeader, udpHeader...)
-
-	senderIP := net.ParseIP("192.168.1.100").To4()
-	payload := make([]byte, 0, 4+4+len(packetData))
-	payload = append(payload, magicBytes[:]...)
-	payload = append(payload, senderIP...)
-	payload = append(payload, packetData...)
-
-	encrypted, _ := aes.Encrypt(payload)
-	msg := make([]byte, 2+len(encrypted))
-	binary.BigEndian.PutUint16(msg[0:2], uint16(len(encrypted)))
-	copy(msg[2:], encrypted)
-
-	// Write the message from the client side (simulating remote sender)
-	go func() {
-		client.Write(msg)
-	}()
-
-	// Give the write a moment to complete
-	time.Sleep(50 * time.Millisecond)
-
-	// This should read the message without panicking or erroring
-	pr.readRemoteConnections()
-
-	// Verify the read buffer was initialized
-	if _, ok := pr.remoteReadBufs[server]; !ok {
-		t.Error("expected read buffer to be created for connection")
-	}
+	binary.BigEndian.PutUint16(udpHeader[0:2], sport)
+	binary.BigEndian.PutUint16(udpHeader[2:4], dport)
+	binary.BigEndian.PutUint16(udpHeader[4:6], 8) // udp length
+	return append(ipHeader, udpHeader...)
 }
 
-func TestReadRemoteConnectionsInvalidMagic(t *testing.T) {
-	log := newTestLogger(t)
+// buildRemoteFrame builds a wire frame (length prefix + body) in the current
+// format: seq(8) || magic(4) || senderIP(4) || packet.
+func buildRemoteFrame(t *testing.T, aes *cipher.Cipher, seq uint64, sender string, packet []byte) []byte {
+	t.Helper()
+	senderIP := net.ParseIP(sender).To4()
+	plain := make([]byte, 0, 8+len(magicBytes)+4+len(packet))
+	var seqB [8]byte
+	binary.BigEndian.PutUint64(seqB[:], seq)
+	plain = append(plain, seqB[:]...)
+	plain = append(plain, magicBytes[:]...)
+	plain = append(plain, senderIP...)
+	plain = append(plain, packet...)
+	frame, err := aes.EncryptFrame(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return frame
+}
+
+func newReaderTestRelay(t *testing.T) *PacketRelay {
+	t.Helper()
 	aes, err := cipher.New("")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	pr := &PacketRelay{
-		logger:         log,
+	return &PacketRelay{
+		logger:         newTestLogger(t),
 		aes:            aes,
-		noRemoteRelay:  true,
-		remoteReadBufs: make(map[net.Conn]*remoteReadBuf),
-		remoteTmpBuf:   make([]byte, 4096),
+		done:           make(chan struct{}),
+		remotePacketCh: make(chan remotePacket, 8),
+		remoteFailedCh: make(chan net.Conn, 8),
+		remoteWriters:  make(map[net.Conn]*remoteWriter),
 	}
+}
+
+func TestRunReaderValidFrame(t *testing.T) {
+	pr := newReaderTestRelay(t)
+	defer close(pr.done)
 
 	server, client := net.Pipe()
 	defer server.Close()
 	defer client.Close()
 
-	pr.remoteConnections = []net.Conn{server}
+	packet := minUDPTestPacket("192.168.1.100", "239.255.255.250", 1234, 1900)
+	frame := buildRemoteFrame(t, pr.aes, 1, "192.168.1.100", packet)
 
-	// Build a message with invalid magic bytes
-	payload := make([]byte, 4+4+28) // magic + senderIP + min packet
-	payload[0] = 'X'                // wrong magic
+	pr.startReader(server)
+	go func() { client.Write(frame) }()
 
-	encrypted, _ := aes.Encrypt(payload)
-	msg := make([]byte, 2+len(encrypted))
-	binary.BigEndian.PutUint16(msg[0:2], uint16(len(encrypted)))
-	copy(msg[2:], encrypted)
-
-	go func() {
-		client.Write(msg)
-	}()
-
-	time.Sleep(50 * time.Millisecond)
-
-	// Should not panic — just log and skip the invalid message
-	pr.readRemoteConnections()
+	select {
+	case rp := <-pr.remotePacketCh:
+		if rp.senderAddr.String() != "192.168.1.100" {
+			t.Errorf("expected sender 192.168.1.100, got %s", rp.senderAddr)
+		}
+		if len(rp.data) != len(packet) {
+			t.Errorf("expected %d-byte packet, got %d", len(packet), len(rp.data))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for decoded packet")
+	}
 }
 
-func TestReadRemoteConnectionsDeadConnection(t *testing.T) {
-	log := newTestLogger(t)
-	aes, err := cipher.New("")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pr := &PacketRelay{
-		logger:         log,
-		aes:            aes,
-		noRemoteRelay:  true,
-		connsDirty:     true,
-		remoteReadBufs: make(map[net.Conn]*remoteReadBuf),
-		remoteTmpBuf:   make([]byte, 4096),
-	}
+func TestRunReaderInvalidMagicSkipped(t *testing.T) {
+	pr := newReaderTestRelay(t)
+	defer close(pr.done)
 
 	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
 
-	pr.remoteConnections = []net.Conn{server}
+	// Valid length/seq framing but wrong magic bytes: must be skipped, not fatal.
+	packet := minUDPTestPacket("192.168.1.100", "239.255.255.250", 1234, 1900)
+	frame := buildRemoteFrame(t, pr.aes, 1, "192.168.1.100", packet)
+	// Corrupt the first magic byte (offset: 2 length + 8 seq = 10).
+	frame[10] ^= 0xff
 
-	// Close the client side to simulate a dead connection
+	pr.startReader(server)
+	go func() { client.Write(frame) }()
+
+	select {
+	case <-pr.remotePacketCh:
+		t.Error("invalid-magic frame should not be delivered")
+	case conn := <-pr.remoteFailedCh:
+		t.Errorf("invalid-magic frame should not fail the connection, got %v", conn)
+	case <-time.After(300 * time.Millisecond):
+		// Expected: nothing delivered, connection stays alive.
+	}
+}
+
+func TestRunReaderReplayRejected(t *testing.T) {
+	pr := newReaderTestRelay(t)
+	defer close(pr.done)
+
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	packet := minUDPTestPacket("192.168.1.100", "239.255.255.250", 1234, 1900)
+	pr.startReader(server)
+
+	// seq=5 accepted, replayed seq=5 rejected, seq=6 accepted, older seq=4 rejected.
+	go func() {
+		client.Write(buildRemoteFrame(t, pr.aes, 5, "192.168.1.100", packet))
+		client.Write(buildRemoteFrame(t, pr.aes, 5, "192.168.1.100", packet))
+		client.Write(buildRemoteFrame(t, pr.aes, 6, "192.168.1.100", packet))
+		client.Write(buildRemoteFrame(t, pr.aes, 4, "192.168.1.100", packet))
+	}()
+
+	// Exactly two frames (seq 5 and seq 6) should be delivered.
+	deadline := time.After(2 * time.Second)
+	got := 0
+	for got < 2 {
+		select {
+		case <-pr.remotePacketCh:
+			got++
+		case <-deadline:
+			t.Fatalf("expected 2 accepted frames, got %d", got)
+		}
+	}
+	// No third frame should arrive.
+	select {
+	case <-pr.remotePacketCh:
+		t.Error("replayed/old frame should not have been delivered")
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+func TestRunReaderDeadConnection(t *testing.T) {
+	pr := newReaderTestRelay(t)
+	defer close(pr.done)
+
+	server, client := net.Pipe()
+	defer server.Close()
+
+	pr.startReader(server)
+	// Close the client side to simulate a dead connection.
 	client.Close()
 
-	pr.readRemoteConnections()
-
-	// The dead connection should have been removed
-	if len(pr.remoteConnections) != 0 {
-		t.Errorf("expected 0 connections after dead conn cleanup, got %d", len(pr.remoteConnections))
+	select {
+	case conn := <-pr.remoteFailedCh:
+		if conn != server {
+			t.Error("wrong connection reported failed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for dead connection to be reported")
 	}
-	server.Close()
 }
 
 // --- Close/shutdown tests ---
 
 func TestCloseSignalsLoop(t *testing.T) {
 	pr := &PacketRelay{
-		done:           make(chan struct{}),
-		remoteReadBufs: make(map[net.Conn]*remoteReadBuf),
+		done:          make(chan struct{}),
+		remoteWriters: make(map[net.Conn]*remoteWriter),
 	}
 
 	pr.Close()
@@ -641,10 +689,9 @@ func TestMaxRemoteMessageLenFitsMaxPacket(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Worst-case remote relay payload: magic + senderIP + max-size packet.
-	payload := make([]byte, 0, len(magicBytes)+4+maxPacketSize)
-	payload = append(payload, magicBytes[:]...)
-	payload = append(payload, make([]byte, 4)...)
+	// Worst-case remote relay payload: seq + magic + senderIP + max-size packet.
+	payload := make([]byte, 0, remoteHeaderLen+maxPacketSize)
+	payload = append(payload, make([]byte, remoteHeaderLen)...)
 	payload = append(payload, make([]byte, maxPacketSize)...)
 
 	frame, err := aes.EncryptFrame(payload)
@@ -656,6 +703,89 @@ func TestMaxRemoteMessageLenFitsMaxPacket(t *testing.T) {
 	if bodyLen > maxRemoteMessageLen {
 		t.Errorf("max-size frame body = %d exceeds maxRemoteMessageLen = %d; the receiving peer would reject it and drop the connection", bodyLen, maxRemoteMessageLen)
 	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+func TestRemoteMutualAuthHandshake(t *testing.T) {
+	port := freeTCPPort(t)
+
+	newRelay := func(key string, listen, remote []string) *PacketRelay {
+		pr, err := New(Config{
+			Listen:      listen,
+			Remote:      remote,
+			RemotePort:  port,
+			RemoteRetry: 1,
+			AESKey:      key,
+			Logger:      newTestLogger(t),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pr
+	}
+
+	t.Run("matching keys complete handshake", func(t *testing.T) {
+		server := newRelay("shared-secret", []string{"127.0.0.1"}, nil)
+		defer server.Close()
+		client := newRelay("shared-secret", nil, []string{"127.0.0.1"})
+		defer client.Close()
+
+		go client.dialRemote(client.remoteAddrs[0])
+
+		select {
+		case conn := <-server.acceptCh:
+			conn.Close()
+		case <-time.After(3 * time.Second):
+			t.Fatal("server did not accept an authenticated connection")
+		}
+		select {
+		case res := <-client.connectResultCh:
+			if res.err != nil {
+				t.Fatalf("client handshake failed: %v", res.err)
+			}
+			if res.conn != nil {
+				res.conn.Close()
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("client dial produced no result")
+		}
+	})
+
+	t.Run("mismatched key is rejected", func(t *testing.T) {
+		server := newRelay("right-key", []string{"127.0.0.1"}, nil)
+		defer server.Close()
+		client := newRelay("wrong-key", nil, []string{"127.0.0.1"})
+		defer client.Close()
+
+		go client.dialRemote(client.remoteAddrs[0])
+
+		// The server must not hand up an authenticated connection.
+		select {
+		case conn := <-server.acceptCh:
+			conn.Close()
+			t.Fatal("server accepted a connection with the wrong key")
+		case <-time.After(500 * time.Millisecond):
+		}
+		// The client dial must report an error rather than a usable connection.
+		select {
+		case res := <-client.connectResultCh:
+			if res.err == nil {
+				t.Fatal("client accepted a server it could not authenticate")
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("client dial produced no result")
+		}
+	})
 }
 
 func TestDialRemoteReturnsAfterClose(t *testing.T) {

--- a/go/internal/relay/relay_types.go
+++ b/go/internal/relay/relay_types.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"bytes"
 	"net"
 	"net/netip"
 	"time"
@@ -12,11 +11,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// remoteReadBuf holds per-connection read state for remote TCP relay connections.
-type remoteReadBuf struct {
-	buf        bytes.Buffer
-	msgLen     int
-	lastActive time.Time
+// remotePacket is a decoded packet delivered from a connection's reader
+// goroutine to the main loop for relaying.
+type remotePacket struct {
+	senderAddr netip.Addr
+	data       []byte
+}
+
+// remoteWriter owns the writer goroutine for a single remote connection.
+// The event loop enqueues frames on ch; the goroutine writes them so a slow
+// peer cannot block the loop. done is closed to stop the goroutine.
+type remoteWriter struct {
+	conn net.Conn
+	ch   chan []byte
+	done chan struct{}
 }
 
 // ssdpSearchSource tracks the most recent SSDP search source for unicast reply routing.
@@ -130,12 +138,20 @@ type PacketRelay struct {
 	noRemoteRelay     bool
 	aes               *cipher.Cipher
 	remoteConnections []net.Conn
-	connectedRemotes  []net.Conn // cached union of all active remote connections
-	connsDirty        bool       // true when connectedRemotes needs rebuilding
-	remoteReadBufs    map[net.Conn]*remoteReadBuf
+	connectedRemotes  []net.Conn                 // cached union of all active remote connections
+	connsDirty        bool                       // true when connectedRemotes needs rebuilding
+	remoteWriters     map[net.Conn]*remoteWriter // per-connection writer goroutines
+	remoteSeq         uint64                     // monotonic sequence for outbound frames
 
-	// remoteTmpBuf is a pre-allocated read buffer for remote TCP connection reads.
-	remoteTmpBuf []byte
+	// remotePacketCh receives decoded packets from per-connection reader
+	// goroutines; remoteFailedCh receives connections whose reader hit an error.
+	remotePacketCh chan remotePacket
+	remoteFailedCh chan net.Conn
+
+	// ARP resolution cache for SSDP unicast reply routing (main-loop only).
+	arpCacheIP   string
+	arpCacheMAC  net.HardwareAddr
+	arpCacheTime time.Time
 
 	// Pre-allocated poll structures rebuilt when receivers change.
 	pollFds   []unix.PollFd


### PR DESCRIPTION
This addresses the findings from an adversarial review (Opus 4.8 + Fable) of the Go relay. All changes build, vet clean, and pass the suite (including `-race`); cross-compiles for arm64/armv7 verified.

## Correctness
- **mDNS OOB panic** (`packet.go`): `MdnsSetUnicastBit` read the question-count field (`udpData[4:6]`) with a guard that only required 4 payload bytes, so a crafted 4- or 5-byte mDNS packet crashed the root daemon. The guard now requires the full 12-byte DNS header.
- **Dedup loop with `--ttl`/masquerade** (`relay.go`, `relay_socket.go`): the duplicate-suppression ring recorded the *received* IP checksum before modification, so a packet whose header was rewritten (TTL override, masquerade, SSDP rewrite) was not recognized when it looped back, and could be relayed repeatedly. It now records the *transmitted* checksum, matching the Python reference.
- **Broadcast over remote relay** (`relay.go`): broadcast packets arriving over the remote link were silently dropped because their destination (the sending site's subnet broadcast) never matched a local interface. They are now recognized and re-broadcast onto local interfaces.
- **RFC 768 UDP checksum** (`packet.go`): a computed checksum of `0x0000` is now transmitted as `0xFFFF`.
- **DF on fragments** (`relay_socket.go`): the Don't-Fragment bit is no longer stamped on the tail of a fragment train.

## Security
- **Key derivation** (`cipher.go`): AES and HMAC keys are now derived with PBKDF2-HMAC-SHA256 (210k iterations, domain-separated salts) instead of a single unsalted SHA-256, giving the passphrase a work factor against offline brute force. **Breaking change:** both relay ends must run this version to interoperate.
- **Mutual authentication** (`relay_remote.go`): the handshake is now bidirectional — the client also challenges the server and verifies its response, so a client never relays to an impostor endpoint.
- **Replay protection** (`relay_remote.go`): each remote frame carries a monotonic sequence number; the receiver rejects frames whose sequence does not advance.
- **Privilege drop** (`main.go`): `setgroups` clears inherited supplementary groups before `setgid`/`setuid`. A prominent warning is logged when remote relay runs without `--aes` (no cryptographic peer authentication in that mode).

## Performance / stability
- **Remote I/O off the event loop** (`relay_remote.go`, `relay_loop.go`): remote TCP reads and writes moved into per-connection reader/writer goroutines with bounded queues, so a slow or idle remote peer can no longer stall the single-threaded loop (previously a synchronous 100 ms write per peer per packet, plus a 5 ms blocking read per idle connection each iteration). Poll timeout is shortened when remote relay is active to bound remote latency.
- **Transmit sockets** (`relay_socket.go`): send-only `AF_PACKET` sockets now use protocol `0` instead of `ETH_P_ALL`, removing a kernel receive tap per socket. Interface recovery no longer blocks the loop waiting for an address.
- **Per-packet allocations**: `Info` logging is gated behind an enabled check; the transmit path no longer allocates a throwaway UDP-checksum header or an IP-payload copy; the received buffer is passed through without a pooled copy; per-transmitter copies happen only when masquerading; pooled buffers are sized to fit full frames.
- **ARP cache** (`relay.go`): SSDP unicast reply routing caches the IP→MAC lookup instead of re-reading `/proc/net/arp` per packet.

## Tests
Added coverage for the mDNS short-packet guard, fragment payload assembly, the UDP checksum fixup, remote broadcast detection, replay rejection, the reader-goroutine frame path, and the mutual-auth handshake (matching and mismatched keys).

## Note
The key-derivation change and the new frame format (sequence prefix, mutual-auth handshake) are wire-incompatible with the previous version, so remote relay peers must be upgraded together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcXKDthiSkGvNftDhJ5vXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcXKDthiSkGvNftDhJ5vXT)_