### PR TITLE
fix: RFC 768 UDP checksum, remote-mesh poll latency, race in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run tests
         working-directory: go
-        run: go test ./... -v -count=1
+        run: go test ./... -v -count=1 -race
 
       - name: Run vet
         working-directory: go

--- a/go/internal/relay/packet.go
+++ b/go/internal/relay/packet.go
@@ -77,6 +77,11 @@ func ComputeUDPChecksum(ipHeader, udpHeader, data []byte) []byte {
 	sum = checksumAdd(sum, data)
 
 	checksum := checksumFinalize(sum)
+	if checksum == 0 {
+		// RFC 768: a computed checksum of 0 must be transmitted as all-ones;
+		// 0x0000 on the wire means "no checksum".
+		checksum = 0xffff
+	}
 
 	result := make([]byte, 8)
 	copy(result, udpHeader[:6])

--- a/go/internal/relay/packet_test.go
+++ b/go/internal/relay/packet_test.go
@@ -672,6 +672,23 @@ func TestComputeUDPChecksum(t *testing.T) {
 			t.Errorf("UDP checksum = 0x%04x, want 0x3e62", gotChecksum)
 		}
 	})
+
+	t.Run("zero-valued checksum is transmitted as 0xffff", func(t *testing.T) {
+		// Crafted so the one's-complement sum before inversion is exactly
+		// 0xffff, so the computed checksum inverts to 0x0000. RFC 768
+		// requires that be sent as 0xffff, since 0x0000 on the wire means
+		// "no checksum".
+		ipHeader := make([]byte, 20)
+		ipHeader[9] = 17 // protocol = UDP
+		udpHeader := []byte{0x00, 0x00, 0xff, 0xde, 0x00, 0x08, 0x00, 0x00}
+		var data []byte
+
+		result := ComputeUDPChecksum(ipHeader, udpHeader, data)
+		gotChecksum := binary.BigEndian.Uint16(result[6:8])
+		if gotChecksum != 0xffff {
+			t.Errorf("UDP checksum = 0x%04x, want 0xffff", gotChecksum)
+		}
+	})
 }
 
 func TestOnNetworkPrefix(t *testing.T) {

--- a/go/internal/relay/relay_loop.go
+++ b/go/internal/relay/relay_loop.go
@@ -75,7 +75,7 @@ func (pr *PacketRelay) Loop() error {
 			pr.pollFds[i].Revents = 0
 		}
 
-		n, err := unix.Poll(pr.pollFds, 1000) // 1 second timeout
+		n, err := unix.Poll(pr.pollFds, 100) // 100ms timeout; bounds remote-mesh read latency
 		if err != nil {
 			if err == unix.EINTR {
 				continue


### PR DESCRIPTION
## Summary
- `ComputeUDPChecksum`: a computed checksum of 0 must be transmitted as `0xffff`, since `0x0000` on the wire means "no checksum" (RFC 768). One-line fix in `packet.go`, plus a crafted test case that hits the zero-checksum path.
- `Loop()` poll timeout dropped from 1000ms to 100ms. TCP remote connections (`--remote`/`--listen`) aren't in the `unix.Poll` fd set — they're drained once per loop iteration via `readRemoteConnections()` — so a packet arriving over the mesh during local idle could sit for up to ~1s. Bounding the poll timeout bounds that latency; the extra wakeup cost is negligible.
- CI now runs `go test` with `-race` to cover the accept/dial goroutines in the remote-mesh code.

Not included: KDF hardening for the AES passphrase (sha256 → scrypt/argon2id) — that's wire-breaking across the mesh and needs a version-gated handshake, not a drive-by fix.

## Test plan
- [x] `go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` (this package uses `AF_PACKET` and is Linux-only)
- [x] `GOOS=linux GOARCH=amd64 go vet ./...`
- [x] New test `TestComputeUDPChecksum/zero-valued_checksum_is_transmitted_as_0xffff` — verified the crafted zero-checksum input against a standalone copy of the checksum math (couldn't run the full suite locally on macOS due to the `AF_PACKET` dependency; CI will run it with `-race`)